### PR TITLE
Fix pagination payload building to allow null navigation links

### DIFF
--- a/backend/src/main/java/com/example/bookvopoisk/DTO/PageUtil.java
+++ b/backend/src/main/java/com/example/bookvopoisk/DTO/PageUtil.java
@@ -2,6 +2,7 @@ package com.example.bookvopoisk.DTO;
 
 import org.springframework.data.domain.Page;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class PageUtil {
@@ -13,14 +14,15 @@ public class PageUtil {
     Integer prev = current > 1 ? current - 1 : null;
     Integer next = current < last ? current + 1 : null;
 
-    return Map.of(
-      "data", p.getContent(),
-      "first", 1,
-      "items", p.getTotalElements(),
-      "last", last,
-      "next", next,
-      "page", current,
-      "prev", prev
-    );
+    Map<String, Object> payload = new LinkedHashMap<>();
+    payload.put("data", p.getContent());
+    payload.put("first", 1);
+    payload.put("items", p.getTotalElements());
+    payload.put("last", last);
+    payload.put("next", next);
+    payload.put("page", current);
+    payload.put("prev", prev);
+
+    return payload;
   }
 }


### PR DESCRIPTION
## Summary
- replace Map.of usage in PageUtil with a LinkedHashMap so null prev/next entries no longer cause runtime failures

## Testing
- mvn -q test *(fails: release version 23 not supported in container JDK)*

------
https://chatgpt.com/codex/tasks/task_e_68dace5d2b04833192848688e79a2114