### PR TITLE
Fix JWT secret config binding

### DIFF
--- a/backend/src/main/java/com/example/bookvopoisk/googleRegistration/JwtUtil.java
+++ b/backend/src/main/java/com/example/bookvopoisk/googleRegistration/JwtUtil.java
@@ -27,7 +27,22 @@ public class JwtUtil {
     @Value("${app.auth.jwt.secret}") String secret,
     @Value("${app.auth.jwt.access-ttl-seconds}") long ttlSeconds
   ) {
-    byte[] keyBytes = Decoders.BASE64.decode(secret);   // ← декодируем Base64
+    if (secret == null) {
+      throw new IllegalStateException("JWT secret is not configured (app.auth.jwt.secret)");
+    }
+
+    String normalizedSecret = secret.trim();
+    if (normalizedSecret.isEmpty()) {
+      throw new IllegalStateException("JWT secret must not be blank");
+    }
+
+    byte[] keyBytes;
+    try {
+      keyBytes = Decoders.BASE64.decode(normalizedSecret);   // ← декодируем Base64
+    } catch (IllegalArgumentException ex) {
+      throw new IllegalStateException("JWT secret must be a valid Base64 string", ex);
+    }
+
     if (keyBytes.length < 32) {
       throw new IllegalStateException("JWT secret must be >= 32 bytes after Base64 decoding");
     }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -31,11 +31,11 @@ spring:
             user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
             user-name-attribute: sub
 
-  app:
-    cors:
-      allowed-origins: "https://bookpoisk.vercel.app"
-    auth:
-      frontend-success-url: "https://bookpoisk.vercel.app/auth/done"
-      jwt:
-        secret: ${APP_JWT_SECRET}     # длинный случайный ключ (HS256)
-        access-ttl-seconds: 3600
+app:
+  cors:
+    allowed-origins: "https://bookpoisk.vercel.app"
+  auth:
+    frontend-success-url: "https://bookpoisk.vercel.app/auth/done"
+    jwt:
+      secret: ${APP_JWT_SECRET}     # длинный случайный ключ (HS256)
+      access-ttl-seconds: 3600


### PR DESCRIPTION
## Summary
- move the custom `app.*` configuration block to the top level of `application.yml`
- ensure the JWT secret placeholder resolves to `APP_JWT_SECRET` during deployment

## Testing
- sh mvnw -DskipTests package *(fails: Fatal error compiling – release version 23 not supported in container JDK)*

------
https://chatgpt.com/codex/tasks/task_e_68f695baf29883319f1fec7693b64067